### PR TITLE
Cleanup examples

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,7 @@
 language: clojure
 lein: lein
 dist: xenial
-addons:
-  ssh_known_hosts: shrimp.octet.services
+
 services:
   - docker
 
@@ -11,7 +10,3 @@ before_install:
   - scripts/setup_for_remote_barge.sh $BARGE_URL
   - AGENT_URL=http://52.187.164.74:8080
 script: lein do clean, test
-
-branches:
-  only:
-    - master

--- a/doc/clojureimpl.md
+++ b/doc/clojureimpl.md
@@ -1,11 +1,11 @@
-## Implementing an operation in Clojure
+## Implementing an operation in Koi-clj (in Clojure)
 
 In this document, we'll discuss using koi-clj as a template to implement a new operation in Clojure.
 
-In order to create a new operation, a developer must 
+In order to implement a new operation, a developer must 
 
-- implement the protocols declared [protocols.clj](https://github.com/DEX-Company/koi-clj/blob/develop/src/koi/protocols.clj)
-- create the metadata, which is discussed in detail [here](#) 
+- Implement the protocols declared [protocols.clj](https://github.com/DEX-Company/koi-clj/blob/develop/src/koi/protocols.clj)
+- Create the metadata, which is discussed in detail [here](#) 
 
 The protocol declares three methods
 

--- a/project.clj
+++ b/project.clj
@@ -80,6 +80,7 @@
         koi.examples.filter-empty-rows
         koi.examples.prov-tree-traversal
         koi.examples.failing-asset
+        koi.examples.workshop-join
         ]
   ;:ring {:handler koi.api/app :init koi.api/app-init}
 )

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject sg.dex/koi-clj "0.1.4"
+(defproject sg.dex/koi-clj "0.1.5-SNAPSHOT"
   :description "Ocean Invoke API implementation in Clojure"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
@@ -71,5 +71,6 @@
                       :jvm-opts ["-Dconfig.edn=resources/dev-config.edn"]
                       :main koi.api}}
 
-  :ring { :handler koi.api/app }
+  :ring {:handler koi.api/app
+         :init koi.api/app-init}
 )

--- a/project.clj
+++ b/project.clj
@@ -23,7 +23,8 @@
                  [metosin/compojure-api "2.0.0-alpha28"]
 
                  ;;components
-                 [mount "0.1.12"]
+                 ;[mount "0.1.12"]
+                 [com.stuartsierra/component "0.4.0"]
 
                  [ring "1.6.3"]
                  [metosin/ring-http-response "0.9.0"]
@@ -53,6 +54,8 @@
                  ;;csv manipulation
                  [net.mikera/core.matrix "0.58.0"]
                  [org.clojure/data.csv "0.1.4"]
+
+                 ;;
                  ]
   :plugins [[lein-codox "0.10.7"]]
   :codox {:output-path "codox"}
@@ -70,7 +73,13 @@
              :uberjar{:aot :all 
                       :jvm-opts ["-Dconfig.edn=resources/dev-config.edn"]
                       :main koi.api}}
-
-  :ring {:handler koi.api/app
-         :init koi.api/app-init}
+  :aot [koi.examples.hashing
+        koi.examples.prime-num
+        koi.examples.predict-iris
+        koi.examples.hashing-asset
+        koi.examples.filter-empty-rows
+        koi.examples.prov-tree-traversal
+        koi.examples.failing-asset
+        ]
+  ;:ring {:handler koi.api/app :init koi.api/app-init}
 )

--- a/resources/config.edn
+++ b/resources/config.edn
@@ -2,6 +2,7 @@
  :agent-url #or [#env AGENT_URL "http://52.187.164.74:8080" ]
  :username "Aladdin"
  :password "OpenSesame"
+ :port 3000
  :operations
  {
   ;;note that path name with hyphen (-) must be replaced with underscore, since java doesn't allow hyphens

--- a/resources/config.edn
+++ b/resources/config.edn
@@ -7,12 +7,11 @@
   ;;note that path name with hyphen (-) must be replaced with underscore, since java doesn't allow hyphens
   :primes {:classname "koi.examples.prime_num.PrimeNumbers" :metadata "prime_asset_metadata.json"}
   :assethashing {:classname "koi.examples.hashing_asset.HashingAsset" :metadata "hashing_asset_metadata.json"}
-  :hashing {:classname "koi.examples.hashing.Hashing"
-            :metadata "hashing_metadata.json"}
+  :hashing {:classname "koi.examples.hashing.Hashing" :metadata "hashing_metadata.json"}
   :irisprediction {:classname "koi.examples.predict_iris.PredictIrisClass" :metadata "irisprediction_metadata.json"}
-  :translation {:classname "koi.examples.translate_german_to_en.TranslateClass" :metadata "translate_german_to_en_metadata.json"}
+ ; :translation {:classname "koi.examples.translate_german_to_en.TranslateClass" :metadata "translate_german_to_en_metadata.json"}
   :filter-rows {:classname "koi.examples.filter_empty_rows.FilterRowsClass" :metadata "filter_rows_metadata.json"}
-  :workshop-join-cars {:classname "koi.examples.workshop_join.JoinCarsDatasetClass" :metadata "join_cars_metadata.json"}
+ ; :workshop-join-cars {:classname "koi.examples.workshop_join.JoinCarsDatasetClass" :metadata "join_cars_metadata.json"}
   :prov {:classname "koi.examples.prov_tree_traversal.ProvTraversalClass" :metadata "prov_tree_metadata.json"}
   ;;a testing asset that throws exception
  :fail {:classname "koi.examples.failing_asset.FailingAsset" :metadata "prov_tree_metadata.json"}

--- a/resources/test-config.edn
+++ b/resources/test-config.edn
@@ -1,0 +1,20 @@
+{
+ :agent-url #or [#env AGENT_URL "http://52.187.164.74:8080" ]
+ :username "Aladdin"
+ :password "OpenSesame"
+ :port 3001
+ :operations
+ {
+  ;;note that path name with hyphen (-) must be replaced with underscore, since java doesn't allow hyphens
+  :primes {:classname "koi.examples.prime_num.PrimeNumbers" :metadata "prime_asset_metadata.json"}
+  :assethashing {:classname "koi.examples.hashing_asset.HashingAsset" :metadata "hashing_asset_metadata.json"}
+  :hashing {:classname "koi.examples.hashing.Hashing" :metadata "hashing_metadata.json"}
+  :irisprediction {:classname "koi.examples.predict_iris.PredictIrisClass" :metadata "irisprediction_metadata.json"}
+ ; :translation {:classname "koi.examples.translate_german_to_en.TranslateClass" :metadata "translate_german_to_en_metadata.json"}
+  :filter-rows {:classname "koi.examples.filter_empty_rows.FilterRowsClass" :metadata "filter_rows_metadata.json"}
+  :workshop-join-cars {:classname "koi.examples.workshop_join.JoinCarsDatasetClass" :metadata "join_cars_metadata.json"}
+  :prov {:classname "koi.examples.prov_tree_traversal.ProvTraversalClass" :metadata "prov_tree_metadata.json"}
+  ;;a testing asset that throws exception
+ :fail {:classname "koi.examples.failing_asset.FailingAsset" :metadata "prov_tree_metadata.json"}
+  }}
+

--- a/src/koi/api.clj
+++ b/src/koi/api.clj
@@ -97,17 +97,21 @@
                        :handler oph/result-handler}}))))
 
 (def app
-  (do
-    (mount/start-with-states {#'koi.op-handler/registry
-                              {:start oph/operation-registry}})
-    (api
-     {:swagger
-      {:ui "/"
-       :spec "/swagger1.json"
-       :data {:info {:title "invoke-api "
-                     :description "Invoke with Ocean "}
-              :tags [{:name "invoke service", :description "invoke Ocean services"}]}}}
-     routes)))
+  (api
+   {:swagger
+    {:ui "/"
+     :spec "/swagger1.json"
+     :data {:info {:title "invoke-api "
+                   :description "Invoke with Ocean "}
+            :tags [{:name "invoke service", :description "invoke Ocean services"}]}}}
+   routes))
+
+(defn app-init
+  []
+  (mount/start-with-states {#'koi.op-handler/registry
+                            {:start oph/operation-registry}}))
 
 (defn -main [& args]
-  (run-jetty app {:port (Integer/valueOf (or (System/getenv "port") "3000"))}))
+  (do 
+    (app-init)
+    (run-jetty app {:port (Integer/valueOf (or (System/getenv "port") "3000"))})))

--- a/src/koi/api.clj
+++ b/src/koi/api.clj
@@ -106,16 +106,6 @@
                       500 {:schema spec/any?}}
           :handler oph/result-handler}})))))
 
-#_(def app
-  (api
-   {:swagger
-    {:ui "/"
-     :spec "/swagger1.json"
-     :data {:info {:title "invoke-api "
-                   :description "Invoke with Ocean "}
-            :tags [{:name "invoke service", :description "invoke Ocean services"}]}}}
-   routes))
-
 (defrecord WebServer [port operation-registry]
   component/Lifecycle
   (start [this]
@@ -133,7 +123,7 @@
 
     )
   (stop [this]
-    (println " no-op stopping jetty")
+    (println " stopping jetty")
     (if-let [server (:http-server this)]
       (do (.stop server)
           (.join server)
@@ -144,19 +134,6 @@
   [port]
   (map->WebServer {:port port})
   )
-
-#_(defn app-init
-  ([]
-   (app-init (get-config)))
-  ([config]
-   (info " mount starting with " config)
-   #_(mount/start-with-states {#'koi.op-handler/registry
-                             {:start #(oph/operation-registry config)}})))
-
-#_(defn -main [& args]
-  (do 
-    (app-init)
-    (run-jetty app {:port (Integer/valueOf (or (System/getenv "port") "3000"))})))
 
 (defn default-system
   [config]

--- a/src/koi/api.clj
+++ b/src/koi/api.clj
@@ -109,7 +109,7 @@
 (defrecord WebServer [port operation-registry]
   component/Lifecycle
   (start [this]
-    (println " start jetty at " port)
+    (info " start jetty at " port)
     (try 
       (let [server (run-jetty
                     (koi-routes (:operation-registry operation-registry))
@@ -117,13 +117,13 @@
                      :port (Integer/valueOf (or (System/getenv "port") port))})]
         (assoc this :http-server server))
       (catch Exception e
-        (println " got exception starting jetty " (.getMessage e))
+        (error " got exception starting jetty " (.getMessage e))
         (clojure.stacktrace/print-stack-trace e)
         (assoc this :http-server nil)))
 
     )
   (stop [this]
-    (println " stopping jetty")
+    (info " stopping jetty")
     (if-let [server (:http-server this)]
       (do (.stop server)
           (.join server)

--- a/src/koi/api.clj
+++ b/src/koi/api.clj
@@ -7,6 +7,7 @@
                                        undocumented
                                        GET PUT POST DELETE]]
    [compojure.api.coercion.spec :as spec-coercion]
+   [com.stuartsierra.component :as component]
    [ring.middleware.cors :refer [wrap-cors]]
    [compojure.api.coercion.schema :as cos]
    [compojure.route :as route]
@@ -21,12 +22,12 @@
    [spec-tools.data-spec :as ds]
    [spec-tools.json-schema :as jsc]
    [schema-tools.core :as st]
-   [mount.core :as mount :refer [defstate]]
    [clojure.java.io :as io]
    [koi.middleware.basic-auth :refer [basic-auth-mw]]
    [koi.middleware.authenticated :refer [authenticated-mw]]
    [koi.middleware.token-auth :refer [token-auth-mw]]
    [koi.route-functions.auth.get-auth-credentials :refer [auth-credentials-response]]
+   [koi.config :as config :refer [get-config get-remote-agent]]
    [koi.op-handler :as oph])
   (:import [java.util UUID])
   (:gen-class))
@@ -38,65 +39,74 @@
 (s/def ::auth-header string?)
 (s/def ::auth-response string?)
 
-(def routes
-  (context "/api/v1" []
-           :tags ["Invoke ocean service"]
-           :coercion :spec
+(defn koi-routes
+  [operation-registry]
+  (api
+   {:swagger
+    {:ui "/"
+     :spec "/swagger1.json"
+     :data {:info {:title "invoke-api "
+                   :description "Invoke with Ocean "}
+            :tags [{:name "invoke service", :description "invoke Ocean services"}]}}}
 
-           (context "/auth" []
+   (context "/api/v1" []
+     :tags ["Invoke ocean service"]
+     :coercion :spec
 
-                    (POST "/token" {:as request}
-                         :tags ["Auth"]
-                         :return ::auth-response
-                         :header-params [authorization :- ::auth-header]
-                         :middleware [basic-auth-mw authenticated-mw]
-                         :summary "Returns auth info given a username and password in the '`Authorization`' header."
-                         :description "Authorization header expects '`Basic username:password`' where `username:password`
+     (context "/auth" []
+
+       (POST "/token" {:as request}
+         :tags ["Auth"]
+         :return ::auth-response
+         :header-params [authorization :- ::auth-header]
+         :middleware [basic-auth-mw authenticated-mw]
+         :summary "Returns auth info given a username and password in the '`Authorization`' header."
+         :description "Authorization header expects '`Basic username:password`' where `username:password`
                          is base64 encoded. To adhere to basic auth standards we have to use a field called
                          `username` however we will accept a valid username or email as a value for this key."
-                         (auth-credentials-response request)))
+         (auth-credentials-response request)))
 
-           (context "/invoke/:did" []
-                    :path-params [did :- string?]
-                    :middleware [token-auth-mw authenticated-mw]
-                    (sw/resource
-                     {:post
-                      {:summary "Run an sync operation"
-                       :parameters {:body ::params}
-                       :responses {200 {:schema spec/any?}
-                                   201 {:schema spec/any?}
-                                   404 {:schema spec/any?}
-                                   500 {:schema spec/any?}
-                                   }
-                       :handler oph/invoke-handler}}))
+     (context "/invoke/:did" []
+       :path-params [did :- string?]
+       :middleware [token-auth-mw authenticated-mw]
+       (sw/resource
+        {:post
+         {:summary "Run an sync operation"
+          :parameters {:body ::params}
+          :responses {200 {:schema spec/any?}
+                      201 {:schema spec/any?}
+                      404 {:schema spec/any?}
+                      500 {:schema spec/any?}
+                      }
+          :handler (partial oph/invoke-handler operation-registry)}}))
 
-           (context "/invokeasync/:did" []
-                    :path-params [did :- string?]
-                    :middleware [token-auth-mw authenticated-mw]
-                    (sw/resource
-                     {
-                      :post
-                      {:summary "Run an async operation"
-                       :parameters {:body ::params}
-                       :responses {200 {:schema spec/any?}
-                                   201 {:schema spec/any?}
-                                   404 {:schema spec/any?}
-                                   500 {:schema spec/any?}}
-                       :handler (partial oph/invoke-handler true)}}))
+     (context "/invokeasync/:did" []
+       :path-params [did :- string?]
+       :middleware [token-auth-mw authenticated-mw]
+       (sw/resource
+        {
+         :post
+         {:summary "Run an async operation"
+          :parameters {:body ::params}
+          :responses {200 {:schema spec/any?}
+                      201 {:schema spec/any?}
+                      404 {:schema spec/any?}
+                      500 {:schema spec/any?}}
+          :handler (partial oph/invoke-handler operation-registry true)}}))
 
-           (context "/jobs/:jobid" []
-                    :path-params [jobid :- int?]
-                    :middleware [token-auth-mw authenticated-mw]
-                    (sw/resource
-                     {:get
-                      {:summary "get the status of a job"
-                       :responses {200 {:schema spec/any?}
-                                   422 {:schema spec/any?}
-                                   404 {:schema spec/any?}
-                                   500 {:schema spec/any?}}
-                       :handler oph/result-handler}}))))
+     (context "/jobs/:jobid" []
+       :path-params [jobid :- int?]
+       :middleware [token-auth-mw authenticated-mw]
+       (sw/resource
+        {:get
+         {:summary "get the status of a job"
+          :responses {200 {:schema spec/any?}
+                      422 {:schema spec/any?}
+                      404 {:schema spec/any?}
+                      500 {:schema spec/any?}}
+          :handler oph/result-handler}})))))
 
-(def app
+#_(def app
   (api
    {:swagger
     {:ui "/"
@@ -106,12 +116,45 @@
             :tags [{:name "invoke service", :description "invoke Ocean services"}]}}}
    routes))
 
-(defn app-init
-  []
-  (mount/start-with-states {#'koi.op-handler/registry
-                            {:start oph/operation-registry}}))
+(defrecord WebServer [port operation-registry]
+  component/Lifecycle
+  (start [this]
+    (println " start jetty at " port " oper " operation-registry " - 90 " (:operation-registry operation-registry))
+    (assoc this :http-server
+           (run-jetty
+            (koi-routes (:operation-registry operation-registry))
+            {:port (Integer/valueOf (or (System/getenv "port") port))})))
+  (stop [this]
+    (println " no-op stopping jetty")
+    this))
 
-(defn -main [& args]
+(defn new-webserver
+  [port]
+  (map->WebServer {:port port})
+  )
+
+#_(defn app-init
+  ([]
+   (app-init (get-config)))
+  ([config]
+   (info " mount starting with " config)
+   #_(mount/start-with-states {#'koi.op-handler/registry
+                             {:start #(oph/operation-registry config)}})))
+
+#_(defn -main [& args]
   (do 
     (app-init)
     (run-jetty app {:port (Integer/valueOf (or (System/getenv "port") "3000"))})))
+
+(defn default-system
+  [config]
+  (let [{:keys [port]} config]
+    (component/system-map
+     :config-options config
+     :operation-registry (oph/new-operation-registry config)
+     :app (component/using
+           (new-webserver port)
+           {:operation-registry :operation-registry}))))
+
+(defn -main [& args]
+  (component/start (default-system (aero.core/read-config (clojure.java.io/resource "config.edn")))))

--- a/src/koi/examples/failing_asset.clj
+++ b/src/koi/examples/failing_asset.clj
@@ -7,7 +7,7 @@
             invoke-async
             valid-args?]]
    [clojure.java.io :as io]
-   [koi.utils :as utils :refer [put-asset get-asset-content get-asset remote-agent keccak512
+   [koi.utils :as utils :refer [put-asset get-asset-content get-asset keccak512
                                 async-handler
                                 process]]
    [koi.invokespec :as ispec]
@@ -21,16 +21,16 @@
   [agent {:keys [dummy]}]
   (throw (Exception. "test exception")))
 
-(deftype FailingAsset [jobs jobids]
+(deftype FailingAsset [agent jobs jobids]
   :load-ns true
 
   prot/PSyncInvoke
   (invoke-sync [_ args]
-    (process args run-method))
+    (process agent args run-method))
 
   prot/PAsyncInvoke
   (invoke-async [_ args]
-    (async-handler jobids jobs #(process args run-method)))
+    (async-handler jobids jobs #(process agent args run-method)))
 
   prot/PValidParams
   (valid-args? [_ args]
@@ -38,5 +38,5 @@
   )
 
 (defn new-failing
-  [jobs jobids]
-  (FailingAsset. jobs jobids))
+  [agent jobs jobids]
+  (FailingAsset. agent jobs jobids))

--- a/src/koi/examples/failing_asset.clj
+++ b/src/koi/examples/failing_asset.clj
@@ -5,7 +5,7 @@
    [koi.protocols :as prot 
     :refer [invoke-sync
             invoke-async
-            get-params]]
+            valid-args?]]
    [clojure.java.io :as io]
    [koi.utils :as utils :refer [put-asset get-asset-content get-asset remote-agent keccak512
                                 async-handler
@@ -22,6 +22,7 @@
   (throw (Exception. "test exception")))
 
 (deftype FailingAsset [jobs jobids]
+  :load-ns true
 
   prot/PSyncInvoke
   (invoke-sync [_ args]
@@ -30,10 +31,11 @@
   prot/PAsyncInvoke
   (invoke-async [_ args]
     (async-handler jobids jobs #(process args run-method)))
-  
-  prot/PParams
-  (get-params [_]
-    ::params))
+
+  prot/PValidParams
+  (valid-args? [_ args]
+    {:valid? (sp/valid? ::params args)})
+  )
 
 (defn new-failing
   [jobs jobids]

--- a/src/koi/examples/filter_empty_rows.clj
+++ b/src/koi/examples/filter_empty_rows.clj
@@ -7,7 +7,7 @@
    [clojure.core.matrix.dataset :as cd]
   [clojure.data.csv :as csv]
    [starfish.core :as s ]
-   [koi.utils :as utils :refer [put-asset get-asset-content remote-agent process async-handler
+   [koi.utils :as utils :refer [put-asset get-asset-content process async-handler
                                 get-asset]]
    [taoensso.timbre :as timbre
     :refer [log  trace  debug  info  warn  error  fatal  report
@@ -59,15 +59,15 @@
                             :content res-data}]}]
         res))))
 
-(deftype FilterRowsClass [jobs jobids]
+(deftype FilterRowsClass [agent jobs jobids]
   :load-ns true
   prot/PSyncInvoke
   (invoke-sync [_ args]
-    (process args filter-rows))
+    (process agent args filter-rows))
 
   prot/PAsyncInvoke
   (invoke-async [_ args]
-    (async-handler jobids jobs #(process args filter-rows)))
+    (async-handler jobids jobs #(process agent args filter-rows)))
 
   prot/PValidParams
   (valid-args? [_ args]

--- a/src/koi/examples/filter_empty_rows.clj
+++ b/src/koi/examples/filter_empty_rows.clj
@@ -16,7 +16,7 @@
    [koi.protocols :as prot 
     :refer [invoke-sync
             invoke-async
-            get-params]]
+            valid-args?]]
    [koi.invokespec :as ispec]
    [clojure.java.io :as io]
    [aero.core :refer (read-config)]
@@ -60,7 +60,7 @@
         res))))
 
 (deftype FilterRowsClass [jobs jobids]
-
+  :load-ns true
   prot/PSyncInvoke
   (invoke-sync [_ args]
     (process args filter-rows))
@@ -69,6 +69,7 @@
   (invoke-async [_ args]
     (async-handler jobids jobs #(process args filter-rows)))
 
-  prot/PParams
-  (get-params [_]
-    ::params))
+  prot/PValidParams
+  (valid-args? [_ args]
+    {:valid? (sp/valid? ::params args)})
+  )

--- a/src/koi/examples/hashing.clj
+++ b/src/koi/examples/hashing.clj
@@ -26,7 +26,7 @@
   {:results {:keccak256 (Hash/keccak256String cont)
              :keccak512 (keccak512 cont)}})
 
-(deftype Hashing [jobs jobids]
+(deftype Hashing [agent jobs jobids]
   :load-ns true
 
   prot/PSyncInvoke

--- a/src/koi/examples/hashing.clj
+++ b/src/koi/examples/hashing.clj
@@ -4,7 +4,7 @@
    [koi.protocols :as prot 
     :refer [invoke-sync
             invoke-async
-            get-params]]
+            valid-args?]]
    [koi.invokespec :as ispec]
    [koi.utils :as utils :refer [get-asset-content keccak512]]
    [taoensso.timbre :as timbre
@@ -27,6 +27,7 @@
              :keccak512 (keccak512 cont)}})
 
 (deftype Hashing [jobs jobids]
+  :load-ns true
 
   prot/PSyncInvoke
   (invoke-sync [_ args]
@@ -54,6 +55,6 @@
         .start)
       {:jobid jobid}))
   
-  prot/PParams
-  (get-params [_]
-    ::params))
+  prot/PValidParams
+  (valid-args? [_ args]
+    {:valid? (sp/valid? ::params args)}))

--- a/src/koi/examples/hashing_asset.clj
+++ b/src/koi/examples/hashing_asset.clj
@@ -12,7 +12,7 @@
             valid-args?]]
    [koi.invokespec :as ispec]
    [clojure.java.io :as io]
-   [koi.utils :as utils :refer [put-asset get-asset-content get-asset remote-agent keccak512
+   [koi.utils :as utils :refer [put-asset get-asset-content get-asset keccak512
                                 process]]
    [aero.core :refer (read-config)]
    [spec-tools.json-schema :as jsc])
@@ -46,11 +46,11 @@
         (info " result of execfn " res)
         res))))
 
-(deftype HashingAsset [jobs jobids]
+(deftype HashingAsset [agent jobs jobids]
   :load-ns true
   prot/PSyncInvoke
   (invoke-sync [_ args]
-    (process args compute-hash))
+    (process agent args compute-hash))
 
   prot/PAsyncInvoke
   (invoke-async [_ args]
@@ -58,7 +58,7 @@
       (doto (Thread.
              (fn []
                (swap! jobs assoc jobid {:status :accepted})
-               (try (let [res (process args compute-hash)]
+               (try (let [res (process agent args compute-hash)]
                       (swap! jobs assoc jobid
                              {:status :succeeded
                               :results (:results res)}))

--- a/src/koi/examples/hashing_asset.clj
+++ b/src/koi/examples/hashing_asset.clj
@@ -9,7 +9,7 @@
    [koi.protocols :as prot 
     :refer [invoke-sync
             invoke-async
-            get-params]]
+            valid-args?]]
    [koi.invokespec :as ispec]
    [clojure.java.io :as io]
    [koi.utils :as utils :refer [put-asset get-asset-content get-asset remote-agent keccak512
@@ -47,7 +47,7 @@
         res))))
 
 (deftype HashingAsset [jobs jobids]
-
+  :load-ns true
   prot/PSyncInvoke
   (invoke-sync [_ args]
     (process args compute-hash))
@@ -71,6 +71,7 @@
         .start)
       {:jobid jobid}))
 
-  prot/PParams
-  (get-params [_]
-    ::params))
+  prot/PValidParams
+  (valid-args? [_ args]
+    {:valid? (sp/valid? ::params args)})
+  )

--- a/src/koi/examples/predict_iris.clj
+++ b/src/koi/examples/predict_iris.clj
@@ -12,7 +12,7 @@
             valid-args?]]
    [koi.invokespec :as ispec]
    [clojure.java.io :as io]
-   [koi.utils :as utils :refer [put-asset get-asset-content get-asset remote-agent keccak512
+   [koi.utils :as utils :refer [put-asset get-asset-content get-asset keccak512
                                 async-handler
                                 process]]
    [aero.core :refer (read-config)]
@@ -43,15 +43,15 @@
         ;(info " result of predict-class " res)
         res))))
 
-(deftype PredictIrisClass [jobs jobids]
+(deftype PredictIrisClass [agent jobs jobids]
   :load-ns true
   prot/PSyncInvoke
   (invoke-sync [_ args]
-    (process args predict-class))
+    (process agent args predict-class))
 
   prot/PAsyncInvoke
   (invoke-async [_ args]
-    (async-handler jobids jobs #(process args predict-class)))
+    (async-handler jobids jobs #(process agent args predict-class)))
 
   prot/PValidParams
   (valid-args? [_ args]

--- a/src/koi/examples/predict_iris.clj
+++ b/src/koi/examples/predict_iris.clj
@@ -9,7 +9,7 @@
    [koi.protocols :as prot 
     :refer [invoke-sync
             invoke-async
-            get-params]]
+            valid-args?]]
    [koi.invokespec :as ispec]
    [clojure.java.io :as io]
    [koi.utils :as utils :refer [put-asset get-asset-content get-asset remote-agent keccak512
@@ -44,7 +44,7 @@
         res))))
 
 (deftype PredictIrisClass [jobs jobids]
-
+  :load-ns true
   prot/PSyncInvoke
   (invoke-sync [_ args]
     (process args predict-class))
@@ -53,6 +53,6 @@
   (invoke-async [_ args]
     (async-handler jobids jobs #(process args predict-class)))
 
-  prot/PParams
-  (get-params [_]
-    ::params))
+  prot/PValidParams
+  (valid-args? [_ args]
+    {:valid? (sp/valid? ::params args)}))

--- a/src/koi/examples/prime_num.clj
+++ b/src/koi/examples/prime_num.clj
@@ -10,7 +10,7 @@
    [koi.protocols :as prot 
     :refer [invoke-sync
             invoke-async
-            get-params]]
+            valid-args?]]
    [koi.invokespec :as ispec]
    [clojure.java.io :as io]
    [aero.core :refer (read-config)]
@@ -54,7 +54,7 @@
       res)))
 
 (deftype PrimeNumbers [jobs jobids]
-
+  :load-ns true
   prot/PSyncInvoke
   (invoke-sync [_ args]
     (process args compute-primes))
@@ -83,6 +83,7 @@
         .start)
       {:jobid jobid}))
   
-  prot/PParams
-  (get-params [_]
-    ::params))
+  prot/PValidParams
+  (valid-args? [_ args]
+    {:valid? (sp/valid? ::params args)})
+  )

--- a/src/koi/examples/prime_num.clj
+++ b/src/koi/examples/prime_num.clj
@@ -2,7 +2,7 @@
   (:require
    [clojure.spec.alpha :as sp]
    [starfish.core :as s]
-   [koi.utils :as utils :refer [put-asset get-asset-content remote-agent process]]
+   [koi.utils :as utils :refer [put-asset get-asset-content process]]
    [taoensso.timbre :as timbre
     :refer [log  trace  debug  info  warn  error  fatal  report
             logf tracef debugf infof warnf errorf fatalf reportf
@@ -53,11 +53,11 @@
       (info " result of execfn " res)
       res)))
 
-(deftype PrimeNumbers [jobs jobids]
+(deftype PrimeNumbers [agent jobs jobids]
   :load-ns true
   prot/PSyncInvoke
   (invoke-sync [_ args]
-    (process args compute-primes))
+    (process agent args compute-primes))
 
   prot/PAsyncInvoke
   (invoke-async [_ args]
@@ -68,7 +68,7 @@
                        (try (Thread/sleep 10000)
                             (catch Exception e))
                        (swap! jobs assoc jobid {:status :running})
-                       (try (let [res (process args compute-primes)]
+                       (try (let [res (process agent args compute-primes)]
                               (swap! jobs assoc jobid
                                      {:status :succeeded
                                       :results (:results res)}))

--- a/src/koi/examples/prov_tree_traversal.clj
+++ b/src/koi/examples/prov_tree_traversal.clj
@@ -62,7 +62,6 @@
 
 (defn prov-data
   [remote-agent asset-id]
-  (println " prov-data " asset-id)
   (let [k1 (walk-fn remote-agent asset-id)]
     (assoc k1 :derived-from (mapv (partial walk-fn remote-agent) (:derived-from k1)))))
 

--- a/src/koi/examples/prov_tree_traversal.clj
+++ b/src/koi/examples/prov_tree_traversal.clj
@@ -9,7 +9,7 @@
    [koi.protocols :as prot 
     :refer [invoke-sync
             invoke-async
-            get-params]]
+            valid-args?]]
    [koi.invokespec :as ispec]
    [clojure.walk :refer [keywordize-keys]]
    [clojure.java.io :as io]
@@ -77,7 +77,7 @@
       res)))
 
 (deftype ProvTraversalClass [jobs jobids]
-
+  :load-ns true
   prot/PSyncInvoke
   (invoke-sync [_ args]
     (process args prov-tree-fn))
@@ -86,6 +86,6 @@
   (invoke-async [_ args]
     (async-handler jobids jobs #(process args prov-tree-fn)))
 
-  prot/PParams
-  (get-params [_]
-    ::params))
+  prot/PValidParams
+  (valid-args? [_ args]
+    {:valid? (sp/valid? ::params args)}))

--- a/src/koi/examples/prov_tree_traversal.clj
+++ b/src/koi/examples/prov_tree_traversal.clj
@@ -13,7 +13,7 @@
    [koi.invokespec :as ispec]
    [clojure.walk :refer [keywordize-keys]]
    [clojure.java.io :as io]
-   [koi.utils :as utils :refer [put-asset get-asset-content get-asset remote-agent keccak512
+   [koi.utils :as utils :refer [put-asset get-asset-content get-asset keccak512
                                 async-handler
                                 process]]
    [aero.core :refer (read-config)]
@@ -49,8 +49,8 @@
 
 
 (defn walk-fn
-  [asset-id]
-  (let [ast (s/get-asset (:agent remote-agent) asset-id)
+  [remote-agent asset-id]
+  (let [ast (s/get-asset remote-agent asset-id)
         mdata (s/metadata ast)
         imap {:asset-id asset-id
               :metadata (dissoc mdata :provenance)}]
@@ -61,30 +61,30 @@
       imap)))
 
 (defn prov-data
-  [asset-id]
+  [remote-agent asset-id]
   (println " prov-data " asset-id)
-  (let [k1 (walk-fn asset-id)]
-    (assoc k1 :derived-from (mapv walk-fn (:derived-from k1)))))
+  (let [k1 (walk-fn remote-agent asset-id)]
+    (assoc k1 :derived-from (mapv (partial walk-fn remote-agent) (:derived-from k1)))))
 
 (defn prov-tree-fn
-  [agent {:keys [asset]}]
+  [remote-agent {:keys [asset]}]
   (fn []
-    (let [data (json/write-str (prov-data (:did asset)))
+    (let [data (json/write-str (prov-data remote-agent (:did asset)))
           res {:dependencies [asset] 
                :results [{:param-name :prov-tree
                           :type :json
                           :content data}]}]
       res)))
 
-(deftype ProvTraversalClass [jobs jobids]
+(deftype ProvTraversalClass [agent jobs jobids]
   :load-ns true
   prot/PSyncInvoke
   (invoke-sync [_ args]
-    (process args prov-tree-fn))
+    (process agent args prov-tree-fn))
 
   prot/PAsyncInvoke
   (invoke-async [_ args]
-    (async-handler jobids jobs #(process args prov-tree-fn)))
+    (async-handler jobids jobs #(process agent args prov-tree-fn)))
 
   prot/PValidParams
   (valid-args? [_ args]

--- a/src/koi/examples/translate_german_to_en.clj
+++ b/src/koi/examples/translate_german_to_en.clj
@@ -9,7 +9,7 @@
    [koi.protocols :as prot 
     :refer [invoke-sync
             invoke-async
-            get-params]]
+            valid-args?]]
    [koi.invokespec :as ispec]
    [clojure.java.io :as io]
    [clojure.data.json :as json]
@@ -56,6 +56,7 @@
   (invoke-async [_ args]
     (async-handler jobids jobs #(process args translate-dataset)))
 
-  prot/PParams
-  (get-params [_]
-    ::params))
+  prot/PValidParams
+  (valid-args? [_ args]
+    {:valid? (sp/valid? ::params args)})
+  )

--- a/src/koi/examples/workshop_join.clj
+++ b/src/koi/examples/workshop_join.clj
@@ -9,7 +9,7 @@
    [koi.protocols :as prot 
     :refer [invoke-sync
             invoke-async
-            get-params]]
+            valid-args?]]
    [koi.invokespec :as ispec]
    [clojure.java.io :as io]
    [koi.utils :as utils :refer [put-asset get-asset-content get-asset remote-agent keccak512
@@ -58,7 +58,7 @@
       res)))
 
 (deftype JoinCarsDatasetClass [jobs jobids]
-
+  :load-ns true
   prot/PSyncInvoke
   (invoke-sync [_ args]
     (process args join-dataset-fn))
@@ -67,6 +67,7 @@
   (invoke-async [_ args]
     (async-handler jobids jobs #(process args join-dataset-fn)))
 
-  prot/PParams
-  (get-params [_]
-    ::params))
+  prot/PValidParams
+  (valid-args? [_ args]
+    {:valid? (sp/valid? ::params args)})
+  )

--- a/src/koi/examples/workshop_join.clj
+++ b/src/koi/examples/workshop_join.clj
@@ -12,7 +12,7 @@
             valid-args?]]
    [koi.invokespec :as ispec]
    [clojure.java.io :as io]
-   [koi.utils :as utils :refer [put-asset get-asset-content get-asset remote-agent keccak512
+   [koi.utils :as utils :refer [put-asset get-asset-content get-asset keccak512
                                 async-handler
                                 process]]
    [aero.core :refer (read-config)]
@@ -57,15 +57,15 @@
       (info " result of join-dataset " res)
       res)))
 
-(deftype JoinCarsDatasetClass [jobs jobids]
+(deftype JoinCarsDatasetClass [agent jobs jobids]
   :load-ns true
   prot/PSyncInvoke
   (invoke-sync [_ args]
-    (process args join-dataset-fn))
+    (process agent args join-dataset-fn))
 
   prot/PAsyncInvoke
   (invoke-async [_ args]
-    (async-handler jobids jobs #(process args join-dataset-fn)))
+    (async-handler jobids jobs #(process agent args join-dataset-fn)))
 
   prot/PValidParams
   (valid-args? [_ args]

--- a/src/koi/op_handler.clj
+++ b/src/koi/op_handler.clj
@@ -83,8 +83,8 @@
                     (catch Exception e
                       (error " failed to register operations ")
                       (clojure.stacktrace/print-stack-trace e)))
-         _ (println " op-keys " op-keys  "op -impl " op-impls
-                    " regd-ids " regd-ids)
+         _ (info " op-keys " op-keys  "\n op -impl " op-impls
+                    "\n regd-ids " regd-ids)
          res (merge (zipmap op-keys op-impls)
                     (zipmap regd-ids op-impls))]
      ;;return a map that has the asset/operation id as key and value is the operation class
@@ -116,13 +116,10 @@
   ([registry async? inp]
    (let [params (or (:body-params inp) (:body inp))
          {:keys [did]} (:route-params inp) ]
-     (println " invoke handler input " (keys inp) " raw " inp)
      (if-let [ep (registry (keyword did))]
        (let [params-check (valid-args? ep params)
              valid? (:valid? params-check) ]
-         (println " validator " [params-check valid? ep (class ep)])
          (if valid?
-            ; (and validator params (sp/valid? validator params))
            (do
              (info " valid request, making invoke request with " params)
              (if async?

--- a/src/koi/op_handler.clj
+++ b/src/koi/op_handler.clj
@@ -82,11 +82,15 @@
                     ;(register-operations (:agent (get-remote-agent conf)) operations)
                     (catch Exception e
                       (error " failed to register operations ")
-                      (clojure.stacktrace/print-stack-trace e)))]
+                      (clojure.stacktrace/print-stack-trace e)))
+         _ (println " op-keys " op-keys  "op -impl " op-impls
+                    " regd-ids " regd-ids)
+         res (merge (zipmap op-keys op-impls)
+                    (zipmap regd-ids op-impls))]
      ;;return a map that has the asset/operation id as key and value is the operation class
      ;;merging a map that has the common name of the operation for easier testing.
-     (merge (zipmap op-keys op-impls)
-            (zipmap regd-ids op-impls)))))
+     (println " registered assets " res)
+     res)))
 
 (defrecord OperationRegistry [config]
   component/Lifecycle
@@ -110,12 +114,13 @@
   responds with a job id. Else it returns synchronously."
   ([registry inp] (invoke-handler registry false inp))
   ([registry async? inp]
-   (let [params (:body-params inp)
+   (let [params (or (:body-params inp) (:body inp))
          {:keys [did]} (:route-params inp) ]
+     (println " invoke handler input " (keys inp) " raw " inp)
      (if-let [ep (registry (keyword did))]
        (let [params-check (valid-args? ep params)
              valid? (:valid? params-check) ]
-         ;(println " validator " [validator params ])
+         (println " validator " [params-check valid? ep (class ep)])
          (if valid?
             ; (and validator params (sp/valid? validator params))
            (do

--- a/src/koi/op_handler.clj
+++ b/src/koi/op_handler.clj
@@ -90,14 +90,14 @@
                     (zipmap regd-ids op-impls))]
      ;;return a map that has the asset/operation id as key and value is the operation class
      ;;merging a map that has the common name of the operation for easier testing.
-     (println " registered assets " res)
+     (info " registered assets " res)
      res)))
 
 (defrecord OperationRegistry [agent config]
   component/Lifecycle
 
   (start [component]
-    (println ";; Starting registry ")
+    (info ";; Starting operation registry ")
     (let [reg (operation-registry (:agent agent)
                                   (fn[cfg]
                                     (register-operations (:agent (:agent agent))
@@ -106,7 +106,7 @@
       (assoc component :operation-registry reg)))
 
   (stop [component]
-    (println ";; Stopping registry ")
+    (info ";; Stopping registry ")
     (assoc component :operation-registry nil)))
 
 (defrecord Agent [config]
@@ -115,11 +115,11 @@
   (start [component]
     (let [ag (get-remote-agent config)
           res (assoc component :agent ag)]
-      (println ";; Starting agent " )
+      (info ";; Starting agent " )
       res))
 
   (stop [component]
-    (println ";; Stopping agent ")
+    (info ";; Stopping agent ")
     (assoc component :agent nil)))
 
 (defn new-agent

--- a/src/koi/op_handler.clj
+++ b/src/koi/op_handler.clj
@@ -4,31 +4,20 @@
    [cheshire.core :as che :refer :all]
    [starfish.core :as s]
    [clojure.spec.alpha :as sp]
+   [com.stuartsierra.component :as component]
    [koi.protocols :as prot 
     :refer [invoke-sync
             invoke-async
-            get-params]]
+            valid-args?]]
    [ring.util.http-response :as http-response :refer [ok header created unprocessable-entity
                                                       not-found]]
    [ring.util.http-status :as status]
    [clojure.java.io :as io]
-
-   [mount.core :refer [defstate]]
-   [koi.examples.hashing :as h]
-   [koi.examples.hashing-asset :as ha]
-   [koi.examples.failing-asset :as f]
-   [koi.examples.prime-num :as p]
-   [koi.examples.translate-german-to-en :as trans]
-   [koi.examples.predict-iris :as iris]
-   [koi.examples.filter-empty-rows :as filterrows]
-   [koi.examples.workshop-join :as wk]
-   [koi.examples.prov-tree-traversal :as prov]
-   [koi.utils :refer [remote-agent]]
    [taoensso.timbre :as timbre
     :refer [log  trace  debug  info  warn  error  fatal  report
             logf tracef debugf infof warnf errorf fatalf reportf
             spy get-env]]
-   [koi.config :as config :refer [get-config]]))
+   [koi.config :as config :refer [get-config get-remote-agent]]))
 
 ;;the jobs are stored as in-memory atoms. A production setup might
 ;;want to store the jobs in persisten (e.g db) storage
@@ -63,35 +52,72 @@
 
 (defn operation-registry
   "return a map that acts as an operation registry. Key is operation id/common name
-  and value is the implementation class to be called"
-  []
-  (let [operations (:operations (get-config))
-        op-keys (keys operations)
-        op-impls (mapv #(do
-                          (info " loading " %)
-                          (clojure.lang.Reflector/invokeConstructor
-                           (resolve (symbol %))
-                           (to-array [jobs jobids])))
-                       (mapv (fn[[k v]] (:classname v)) operations))
-        regd-ids (register-operations (:agent remote-agent) operations)]
-    ;;return a map that has the asset/operation id as key and value is the operation class
-    ;;merging a map that has the common name of the operation for easier testing.
-    (merge (zipmap op-keys op-impls)
-           (zipmap regd-ids op-impls))))
+  and value is the implementation class to be called.
+  The register-fn takes a configuration map that registers the operations. If the agent is local,
+  then use local registration mechanism, else use a remote agent.
+  "
+  ([] (operation-registry (get-config)))
+  ([conf](operation-registry (fn[config]
+                               (register-operations (:agent (get-remote-agent config))
+                                                    (:operations config)))
+                             conf))
+  ([register-fn conf]
+   (let [operations (:operations conf)
+         op-keys (keys operations)
+         op-impls (mapv #(do
+                           (try 
+                             (info " loading " %)
+                             (clojure.lang.Reflector/invokeConstructor
+                              (resolve (symbol %))
+                              (to-array [jobs jobids]))
 
+                             (catch Exception e
+                               (do 
+                                 (error " failed to load operation class " %)
+                                 (clojure.stacktrace/print-stack-trace e)))))
+                        (mapv (fn[[k v]] (:classname v)) operations))
+         regd-ids (try
+                    (info " registering operations ")
+                    (register-fn conf)
+                    ;(register-operations (:agent (get-remote-agent conf)) operations)
+                    (catch Exception e
+                      (error " failed to register operations ")
+                      (clojure.stacktrace/print-stack-trace e)))]
+     ;;return a map that has the asset/operation id as key and value is the operation class
+     ;;merging a map that has the common name of the operation for easier testing.
+     (merge (zipmap op-keys op-impls)
+            (zipmap regd-ids op-impls)))))
 
-(defstate registry :start (operation-registry))
+(defrecord OperationRegistry [config]
+  component/Lifecycle
+
+  (start [component]
+    (println ";; Starting registry ")
+    (let [reg (operation-registry config)]
+      (assoc component :operation-registry reg)))
+
+  (stop [component]
+    (println ";; Stopping registry ")
+    (assoc component :operation-registry nil)))
+                                        ;(defstate registry :start (operation-registry))
+
+(defn new-operation-registry
+  [config]
+  (map->OperationRegistry {:config config}))
 
 (defn invoke-handler
   "this method handles API calls to /invoke. The first argument is a boolean value, if true,
   responds with a job id. Else it returns synchronously."
-  ([inp] (invoke-handler false inp))
-  ([async? inp]
+  ([registry inp] (invoke-handler registry false inp))
+  ([registry async? inp]
    (let [params (:body-params inp)
          {:keys [did]} (:route-params inp) ]
      (if-let [ep (registry (keyword did))]
-       (let [validator (get-params ep) ]
-         (if (and validator params (sp/valid? validator params))
+       (let [params-check (valid-args? ep params)
+             valid? (:valid? params-check) ]
+         ;(println " validator " [validator params ])
+         (if valid?
+            ; (and validator params (sp/valid? validator params))
            (do
              (info " valid request, making invoke request with " params)
              (if async?
@@ -115,7 +141,11 @@
                      (http-response/internal-server-error " server error executing operation "))))))
            (do
              (error " invalid request, sending error in invoke request with " params)
-             (http-response/bad-request (str " invalid request: " (if params (clojure.string/join (validator params)) " params is not present") " - " )))))
+             (http-response/bad-request (str " invalid request: "
+                                             #_(if params (clojure.string/join
+                                                         (validator params))
+                                                 " params is not present")
+                                             " - " )))))
        (do (error " invalid operation did " did)
            (not-found (str "operation did " did " is a valid resource "))))))) 
 

--- a/src/koi/protocols.clj
+++ b/src/koi/protocols.clj
@@ -10,7 +10,9 @@
   (invoke-async [m args]
     "This method invokes the invoke job. Should return a job id"))
 
-(defprotocol PParams
-  "returns metadata relevant to a service"
-  (get-params [m]
-    "returns the params for validation"))
+(defprotocol PValidParams
+  "returns a map with keys valid? and description. If valid? is true,
+  then the invoke request is delegated to invoke or invoke async"
+  (valid-args? [m args]
+    "returns a map with keys valid? and description. If valid? is true,
+  then the invoke request is delegated to invoke or invoke async"))

--- a/src/koi/utils.clj
+++ b/src/koi/utils.clj
@@ -30,6 +30,7 @@
 
 (defn get-asset
   [agent asset-param]
+  (println " get-asset " agent " asset-param " asset-param)
   (->> asset-param
        :did
        (s/get-asset agent)))
@@ -45,13 +46,13 @@
 (def prime-metadata 
   (->> (clojure.java.io/resource "prime_asset_metadata.json") slurp))
 
-(defstate remote-agent :start (get-remote-agent))
+;;(defstate remote-agent :start (get-remote-agent))
 
 
 (defn invoke-metadata
   "creates invoke metadata given result parameter name, a list of dependencies (which are Assets),
   and a string representation of input params"
-  [param-name dependencies params]
+  [remote-agent param-name dependencies params]
   (s/invoke-prov-metadata (.toString (UUID/randomUUID))
                           ;;this is incorrect, it should be koi's did, not surfer's. 
                           (.toString (:did remote-agent))
@@ -65,8 +66,9 @@
 
   It executes the function to compute the results, creates provenance metadata , registers the asset(s)
   and uploads the contents"
-  [params execfn]
+  [remote-agent params execfn]
   (let [agent (:agent remote-agent)
+        _ (println " process fn agent " agent)
         to-exec (execfn agent params)
         {:keys [dependencies results]} (to-exec)
         res (->> results
@@ -74,7 +76,9 @@
                  (mapv (fn[{:keys [param-name content type
                                    metadata] :or {metadata {}} :as c}]
                          (if (= type :asset)
-                           (let [inv-metadata (invoke-metadata (name param-name) dependencies (JSON/toString params))
+                           (let [inv-metadata (invoke-metadata
+                                               remote-agent
+                                               (name param-name) dependencies (JSON/toString params))
                                  asset (s/asset (s/memory-asset (merge metadata
                                                                        inv-metadata)
                                                                 content))
@@ -107,5 +111,3 @@
                             :description (str "Got exception " (.getMessage e))})))))
       .start)
     {:jobid jobid}))
-
-

--- a/src/koi/utils.clj
+++ b/src/koi/utils.clj
@@ -30,7 +30,6 @@
 
 (defn get-asset
   [agent asset-param]
-  (println " get-asset " agent " asset-param " asset-param)
   (->> asset-param
        :did
        (s/get-asset agent)))
@@ -68,7 +67,6 @@
   and uploads the contents"
   [remote-agent params execfn]
   (let [agent (:agent remote-agent)
-        _ (println " process fn agent " agent)
         to-exec (execfn agent params)
         {:keys [dependencies results]} (to-exec)
         res (->> results


### PR DESCRIPTION
* Change to component instead of mount
* Run local tests only
* validation of payload done by the implementation
* operation implementation classes load on demand