### PR TITLE
 revert separate APIs for job status and  result

### DIFF
--- a/src/koi/api.clj
+++ b/src/koi/api.clj
@@ -111,11 +111,23 @@
                           :handler (oph/invoke-async-handler registry)}}))
 
               (context
-                  "/invoke/job" []
+                  "/invoke/jobs" []
                   :tags ["job details"]
                   :coercion :spec
 
-                  (context "/status/:jobid" []
+                  (context "/:jobid" []
+                    :path-params [jobid :- int?]
+                    :middleware [basic-auth-mw token-auth-mw authenticated-mw]
+                    (sw/resource
+                     {:get
+                      {:summary "get the status of a job"
+                       :responses {200 {:schema spec/any?}
+                                   422 {:schema spec/any?}
+                                   404 {:schema spec/any?}
+                                   500 {:schema spec/any?}}
+                       :handler oph/combined-handler}}))
+
+                  #_(context "/status/:jobid" []
                     :path-params [jobid :- int?]
                     :middleware [basic-auth-mw token-auth-mw authenticated-mw]
                     (sw/resource
@@ -126,18 +138,25 @@
                                    404 {:schema spec/any?}
                                    500 {:schema spec/any?}}
                        :handler oph/status-handler}}))
+                  #_(context "/status" []
+                    :tags ["job details"]
+                    :coercion :spec
+                    )
 
-                  (context "/result/:jobid" []
-                    :path-params [jobid :- int?]
-                    :middleware [basic-auth-mw token-auth-mw authenticated-mw]
-                    (sw/resource
-                     {:get
-                      {:summary "get the result of a job"
-                       :responses {200 {:schema spec/any?}
-                                   404 {:schema spec/any?}
-                                   400 {:schema spec/any?}
-                                   500 {:schema spec/any?}}
-                       :handler oph/result-handler}})))
+                  #_(context "/result" []
+                    :tags ["job details"]
+                    :coercion :spec
+                    (context "/:jobid" []
+                      :path-params [jobid :- int?]
+                      :middleware [basic-auth-mw token-auth-mw authenticated-mw]
+                      (sw/resource
+                       {:get
+                        {:summary "get the result of a job"
+                         :responses {200 {:schema spec/any?}
+                                     404 {:schema spec/any?}
+                                     400 {:schema spec/any?}
+                                     500 {:schema spec/any?}}
+                         :handler oph/result-handler}}))))
               ))))
 
 (defrecord WebServer [port config]

--- a/src/koi/op_handler.clj
+++ b/src/koi/op_handler.clj
@@ -226,6 +226,13 @@
            (error (str " got error in getting job results " e))
            (clojure.stacktrace/print-stack-trace e)))))))
 
+(defn combined-handler
+  "returns the status and the result of the job."
+  ([inp]
+   (let [res (get-results identity inp)]
+     (info (str " combined handler returns " res))
+     res)))
+
 (defn status-handler
   "returns the status of the job."
   ([inp]


### PR DESCRIPTION
As per [this discussion](https://github.com/DEX-Company/DEPs/pull/40#issuecomment-538706630), removing separate APIs for status and result 